### PR TITLE
ci: run build.sh in host environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ before_install:
 - |
   sudo docker run --detach --interactive --tty --privileged \
     --name ${CONTAINER_NAME} \
-    --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR}" \
     --workdir "${TRAVIS_BUILD_DIR}" \
     debian:sid /bin/bash
 - ${CONTAINER_EXEC} apt update -qq
-- ${CONTAINER_EXEC} apt install --no-install-recommends -y docker.io qemu-user-static
+- ${CONTAINER_EXEC} apt install --no-install-recommends -y qemu-user-static
 
 script:
-- ${CONTAINER_EXEC} env DOCKER_USER=${DOCKER_USER} DOCKER_REPO=${DOCKER_REPO} "${TRAVIS_BUILD_DIR}/build.sh"
+- ${CONTAINER_EXEC} /bin/sh -c 'cp /usr/bin/qemu-*-static .'
+- ./build.sh $(${CONTAINER_EXEC} dpkg-query -W -f '\${Version}' qemu-user-static)
 - docker images | grep ^${DOCKER_USER}/${DOCKER_REPO} | awk '{print $1 ":" $2}'
 
 after_success:

--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,17 @@ set -xe
 DOCKER_USER=${DOCKER_USER:-vicamo}
 DOCKER_REPO=${DOCKER_REPO:-qemu-user-static}
 
-cp /usr/bin/qemu-*-static .
+if (($# >= 1)); then
+  debian_version=$1
+  shift;
+else
+  cp /usr/bin/qemu-*-static .
+  debian_version=$(dpkg-query -W -f '${Version}' qemu-user-static)
+fi
 
 first=$(ls -1 qemu-*-static | head -n 1)
 arches=$(ls -1 qemu-*-static | cut -d- -f2)
-version=$(${first} -version | grep ' version ' | sed -e 's,^.* version \([0-9\.]\+\).*$,\1,')
-debian_version=$(dpkg-query -W -f '${Version}' qemu-user-static)
+version=$(./${first} -version | grep ' version ' | sed -e 's,^.* version \([0-9\.]\+\).*$,\1,')
 
 echo <<EOF
 ARCHITECTURES: ${arches}


### PR DESCRIPTION
Previously we tried to install docker inside a debian:sid container
while the host is ubuntu:trusty. This brings an obvious issue that the
docker version may not be the same in between, and docker client/server
must match to communicate to each other.

This changes allows us to copy debian qemu-user-static binaries in the
container, while run the docker build process in the host side.